### PR TITLE
Update .env to allow http or https protocols in BASE_URL

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -1,6 +1,6 @@
 # Server Configuration
 PORT=__PORT__                      # The port the server will listen on
-BASE_URL=https://__DOMAIN__        # The base URL for the application
+BASE_URL=__DOMAIN__                # The base URL for the application
 
 # Upload Settings
 MAX_FILE_SIZE=1024                # Maximum file size in MB


### PR DESCRIPTION
Hey there! haven't used YunoHost but after this: https://github.com/DumbWareio/DumbDrop/pull/32
- users should be able to use either http or https protocols.

I could be wrong but based on this issue it seems like this can be fixed by removing the string interpolation and allowing users to supply the full domainOrLocalIP:port
https://github.com/DumbWareio/DumbDrop/issues/34

let me know i have this completely wrong or if theres anything else that i can help with!